### PR TITLE
Add rsync archive option to maintain Composer binary symlinks during deployment.

### DIFF
--- a/web-starter/templates/config/deploy.rb
+++ b/web-starter/templates/config/deploy.rb
@@ -34,7 +34,7 @@ set :ssh_options, {
 set :platform, "<%= platform %>"
 
 # rsync settings
-set :rsync_options, %w[--recursive --chmod=Dug=rwx,Do=rx --perms --delete --delete-excluded --exclude=.git* --exclude=node_modules]
+set :rsync_options, %w[--archive --recursive --chmod=Dug=rwx,Do=rx --perms --delete --delete-excluded --exclude=.git* --exclude=node_modules]
 set :rsync_copy, "rsync --archive --acls --xattrs"
 set :rsync_cache, "shared/deploy"
 


### PR DESCRIPTION
This addresses https://github.com/forumone/web-starter/issues/275 .

Note that, per William's comments there, I'm not sure we can safely assume we always want this change! Wanted to get the PR started, though.